### PR TITLE
Fix divide-by-zero bug in HSL/HSV conversion

### DIFF
--- a/Color/src/Graphics/Color/Model/HSL.hs
+++ b/Color/src/Graphics/Color/Model/HSL.hs
@@ -104,9 +104,11 @@ rgb2hsl (ColorRGB r g b) = ColorHSL h s l
   where
     !max' = max r (max g b)
     !min' = min r (min g b)
-    !h' | max' == r = (    (g - b) / (max' - min')) / 6
-        | max' == g = (2 + (b - r) / (max' - min')) / 6
-        | max' == b = (4 + (r - g) / (max' - min')) / 6
+    !c' = max' - min'
+    !h' | c'   == 0 = 0
+        | max' == r = (    (g - b) / c') / 6
+        | max' == g = (2 + (b - r) / c') / 6
+        | max' == b = (4 + (r - g) / c') / 6
         | otherwise = 0
     !h
       | h' < 0 = h' + 1

--- a/Color/src/Graphics/Color/Model/HSV.hs
+++ b/Color/src/Graphics/Color/Model/HSV.hs
@@ -120,15 +120,17 @@ rgb2hsv (ColorRGB r g b) = ColorHSV h s v
   where
     !max' = max r (max g b)
     !min' = min r (min g b)
-    !h' | max' == r = (    (g - b) / (max' - min')) / 6
-        | max' == g = (2 + (b - r) / (max' - min')) / 6
-        | max' == b = (4 + (r - g) / (max' - min')) / 6
+    !c' = max' - min'
+    !h' | c'   == 0 = 0
+        | max' == r = (    (g - b) / c') / 6
+        | max' == g = (2 + (b - r) / c') / 6
+        | max' == b = (4 + (r - g) / c') / 6
         | otherwise = 0
     !h
       | h' < 0 = h' + 1
       | otherwise = h'
     !s
       | max' == 0 = 0
-      | otherwise = (max' - min') / max'
+      | otherwise = c' / max'
     !v = max'
 {-# INLINE rgb2hsv #-}


### PR DESCRIPTION
When calculating the hue, the zero case needs to be checked first to prevent a divide-by-zero.  Note that this could be done using `max' == 0` as in the calculation of `s`, but I think that explicitly defining the chroma (`c'`) is more clear, and the value is used more than once in the HSV case regardless.

In the following demonstration program, the hues are calculated as `NaN` without this fix.

```haskell
{-# LANGUAGE DataKinds #-}
{-# LANGUAGE PatternSynonyms #-}

module Main (main) where

-- https://hackage.haskell.org/package/base
import Data.Word (Word8)

-- https://hackage.haskell.org/package/Color
import Graphics.Color.Adaptation.VonKries (convert)
import Graphics.Color.Model (Color)
import Graphics.Color.Space.RGB.Alternative (HSL, HSV, Linearity(NonLinear))
import Graphics.Color.Space.RGB.SRGB (pattern ColorSRGB, SRGB)

------------------------------------------------------------------------------

blackSRGB :: Color (SRGB 'NonLinear) Word8
blackSRGB = ColorSRGB 0x00 0x00 0x00

blackHSV :: Color (HSV (SRGB 'NonLinear)) Float
blackHSV = convert blackSRGB

blackHSL :: Color (HSL (SRGB 'NonLinear)) Float
blackHSL = convert blackSRGB

main :: IO ()
main = do
    print blackHSV
    print blackHSL
```