### PR TITLE
Add fromWord8 to Elevator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.stack-work*
+*~
+.vscode/
+*.yaml.lock
+dist-newstyle

--- a/Color/.gitignore
+++ b/Color/.gitignore
@@ -1,2 +1,0 @@
-.stack-work*
-*~

--- a/Color/src/Graphics/Color/Algebra/Binary.hs
+++ b/Color/src/Graphics/Color/Algebra/Binary.hs
@@ -134,6 +134,9 @@ instance Elevator Bit where
   toShowS _       = ('1':)
   toWord8 = coerce
   {-# INLINE toWord8 #-}
+  fromWord8 0 = zero
+  fromWord8 _ = one
+  {-# INLINE fromWord8 #-}
   toWord16 (Bit 0) = 0
   toWord16 _       = maxBound
   {-# INLINE toWord16 #-}

--- a/Color/src/Graphics/Color/Algebra/Elevator.hs
+++ b/Color/src/Graphics/Color/Algebra/Elevator.hs
@@ -49,6 +49,9 @@ class (Show e, Eq e, Num e, Typeable e, Unbox e, Storable e) => Elevator e where
   -- | Values are scaled to @[0, 255]@ range.
   toWord8 :: e -> Word8
 
+  -- | Values are scaled from @[0, 255]@ range to @[minValue, maxValue]@.
+  fromWord8 :: Word8 -> e
+
   -- | Values are scaled to @[0, 65535]@ range.
   toWord16 :: e -> Word16
 
@@ -158,6 +161,8 @@ instance Elevator Word8 where
   fieldFormat _ = defFieldFormat {fmtWidth = Just 3, fmtChar = 'd'}
   toWord8 = id
   {-# INLINE toWord8 #-}
+  fromWord8 = id
+  {-# INLINE fromWord8 #-}
   toWord16 = raiseUp
   {-# INLINE toWord16 #-}
   toWord32 = raiseUp
@@ -185,6 +190,8 @@ instance Elevator Word16 where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 5, fmtChar = 'd'}
   toWord8 = dropDown
   {-# INLINE toWord8 #-}
+  fromWord8 = raiseUp
+  {-# INLINE fromWord8 #-}
   toWord16 = id
   {-# INLINE toWord16 #-}
   toWord32 = raiseUp
@@ -212,6 +219,8 @@ instance Elevator Word32 where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 10, fmtChar = 'd'}
   toWord8 = dropDown
   {-# INLINE toWord8 #-}
+  fromWord8 = raiseUp
+  {-# INLINE fromWord8 #-}
   toWord16 = dropDown
   {-# INLINE toWord16 #-}
   toWord32 = id
@@ -239,6 +248,8 @@ instance Elevator Word64 where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 20, fmtChar = 'd'}
   toWord8 = dropDown
   {-# INLINE toWord8 #-}
+  fromWord8 = raiseUp
+  {-# INLINE fromWord8 #-}
   toWord16 = dropDown
   {-# INLINE toWord16 #-}
   toWord32 = dropDown
@@ -277,6 +288,8 @@ instance Elevator Word where
 #endif
   toWord8 = dropDown
   {-# INLINE toWord8 #-}
+  fromWord8 = raiseUp
+  {-# INLINE fromWord8 #-}
   toWord16 = dropDown
   {-# INLINE toWord16 #-}
   toWord32 = dropDown
@@ -299,6 +312,8 @@ instance Elevator Int8 where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 3, fmtChar = 'd'}
   toWord8 = raiseUp . max 0
   {-# INLINE toWord8 #-}
+  fromWord8 = dropDown
+  {-# INLINE fromWord8 #-}
   toWord16 = raiseUp . max 0
   {-# INLINE toWord16 #-}
   toWord32 = raiseUp . max 0
@@ -322,6 +337,8 @@ instance Elevator Int16 where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 5, fmtChar = 'd'}
   toWord8 = dropDown . max 0
   {-# INLINE toWord8 #-}
+  fromWord8 = raiseUp
+  {-# INLINE fromWord8 #-}
   toWord16 = raiseUp . max 0
   {-# INLINE toWord16 #-}
   toWord32 = raiseUp . max 0
@@ -345,6 +362,8 @@ instance Elevator Int32 where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 10, fmtChar = 'd'}
   toWord8 = dropDown . max 0
   {-# INLINE toWord8 #-}
+  fromWord8 = raiseUp
+  {-# INLINE fromWord8 #-}
   toWord16 = dropDown . max 0
   {-# INLINE toWord16 #-}
   toWord32 = raiseUp . max 0
@@ -368,6 +387,8 @@ instance Elevator Int64 where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 19, fmtChar = 'd'}
   toWord8 = dropDown . max 0
   {-# INLINE toWord8 #-}
+  fromWord8 = raiseUp
+  {-# INLINE fromWord8 #-}
   toWord16 = dropDown . max 0
   {-# INLINE toWord16 #-}
   toWord32 = dropDown . max 0
@@ -399,6 +420,8 @@ instance Elevator Int where
 #endif
   toWord8 = dropDown . max 0
   {-# INLINE toWord8 #-}
+  fromWord8 = raiseUp
+  {-# INLINE fromWord8 #-}
   toWord16 = dropDown . max 0
   {-# INLINE toWord16 #-}
   toWord32 = dropDown . max 0
@@ -420,6 +443,8 @@ instance Elevator Float where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 11, fmtPrecision = Just 8, fmtChar = 'f'}
   toWord8 = stretch
   {-# INLINE toWord8 #-}
+  fromWord8 = squashTo1
+  {-# INLINE fromWord8 #-}
   toWord16 = stretch
   {-# INLINE toWord16 #-}
   toWord32 = float2Word32
@@ -447,6 +472,8 @@ instance Elevator Double where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 19, fmtPrecision = Just 16, fmtChar = 'f' }
   toWord8 = stretch
   {-# INLINE toWord8 #-}
+  fromWord8 = squashTo1
+  {-# INLINE fromWord8 #-}
   toWord16 = stretch
   {-# INLINE toWord16 #-}
   toWord32 = stretch
@@ -484,6 +511,8 @@ instance (PrintfArg e, Elevator e, RealFloat e) => Elevator (Complex e) where
   toShowS (r :+ i) = toShowS r . formatArg i ((fieldFormat i) {fmtSign = Just SignPlus}) . ('i' :)
   toWord8 = toWord8 . realPart
   {-# INLINE toWord8 #-}
+  fromWord8 = (:+ 0) . fromWord8
+  {-# INLINE fromWord8 #-}
   toWord16 = toWord16 . realPart
   {-# INLINE toWord16 #-}
   toWord32 = toWord32 . realPart

--- a/Color/src/Graphics/Color/Algebra/Elevator.hs
+++ b/Color/src/Graphics/Color/Algebra/Elevator.hs
@@ -297,7 +297,7 @@ instance Elevator Int8 where
   maxValue = maxBound
   minValue = 0
   fieldFormat _ = defFieldFormat { fmtWidth = Just 3, fmtChar = 'd'}
-  toWord8 = fromIntegral . max 0
+  toWord8 = raiseUp . max 0
   {-# INLINE toWord8 #-}
   toWord16 = raiseUp . max 0
   {-# INLINE toWord16 #-}
@@ -322,7 +322,7 @@ instance Elevator Int16 where
   fieldFormat _ = defFieldFormat { fmtWidth = Just 5, fmtChar = 'd'}
   toWord8 = dropDown . max 0
   {-# INLINE toWord8 #-}
-  toWord16 = fromIntegral . max 0
+  toWord16 = raiseUp . max 0
   {-# INLINE toWord16 #-}
   toWord32 = raiseUp . max 0
   {-# INLINE toWord32 #-}
@@ -347,7 +347,7 @@ instance Elevator Int32 where
   {-# INLINE toWord8 #-}
   toWord16 = dropDown . max 0
   {-# INLINE toWord16 #-}
-  toWord32 = fromIntegral . max 0
+  toWord32 = raiseUp . max 0
   {-# INLINE toWord32 #-}
   toWord64 = raiseUp . max 0
   {-# INLINE toWord64 #-}
@@ -372,7 +372,7 @@ instance Elevator Int64 where
   {-# INLINE toWord16 #-}
   toWord32 = dropDown . max 0
   {-# INLINE toWord32 #-}
-  toWord64 = fromIntegral . max 0
+  toWord64 = raiseUp . max 0
   {-# INLINE toWord64 #-}
   toFloat = squashTo1 . max 0
   {-# INLINE toFloat #-}
@@ -394,7 +394,7 @@ instance Elevator Int where
   {-# INLINE toWord64 #-}
 #else
   fieldFormat _ = defFieldFormat { fmtWidth = Just 19, fmtChar = 'd'}
-  toWord64 = fromIntegral . max 0
+  toWord64 = raiseUp . max 0
   {-# INLINE toWord64 #-}
 #endif
   toWord8 = dropDown . max 0

--- a/Color/tests/Graphics/Color/Algebra/ElevatorSpec.hs
+++ b/Color/tests/Graphics/Color/Algebra/ElevatorSpec.hs
@@ -170,7 +170,6 @@ spec =
         pos = fromIntegral . max 0
     describe "Int8" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int8)
-      eprop "toWord8" $ \(e :: Int8) -> pos e === toWord8 e
       eprop "fromRealFloat . toFloat :: Float" $ \(e :: Int8) ->
         (pos e :: Int8) === fromRealFloat (toFloat e :: Float)
       eprop "fromRealFloat . toRealFloat :: Float" $ \(e :: Int8) ->
@@ -183,7 +182,6 @@ spec =
       eprop "read . toShowS" $ \(e :: Int8) -> e === read (toShowS e "")
     describe "Int16" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int16)
-      eprop "toWord16" $ \(e :: Int16) -> pos e === toWord16 e
       eprop "fromRealFloat . toFloat :: Float" $ \(e :: Int16) ->
         (pos e :: Int16) === fromRealFloat (toFloat e :: Float)
       eprop "fromRealFloat . toRealFloat :: Float" $ \(e :: Int16) ->
@@ -196,7 +194,6 @@ spec =
       eprop "read . toShowS" $ \(e :: Int16) -> e === read (toShowS e "")
     describe "Int32" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int32)
-      eprop "toWord32" $ \(e :: Int32) -> pos e === toWord32 e
       prop "fromRealFloat . toFloat :: Float" $
         forAll (choose (0, maxFloatI)) $ \(e :: Int32) ->
           (pos e :: Int32) === fromRealFloat (toFloat e)
@@ -209,7 +206,6 @@ spec =
       eprop "read . toShowS" $ \(e :: Int32) -> e === read (toShowS e "")
     describe "Int64" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int64)
-      eprop "toWord64" $ \(e :: Int64) -> pos e === toWord64 e
       prop "fromRealFloat . toRealFloat :: Float" $
         forAll (choose (0, maxFloatI)) $ \(e :: Int64) ->
           (pos e :: Int64) === fromRealFloat (toRealFloat e :: Float)

--- a/Color/tests/Graphics/Color/Algebra/ElevatorSpec.hs
+++ b/Color/tests/Graphics/Color/Algebra/ElevatorSpec.hs
@@ -37,6 +37,7 @@ spec =
     describe "Word8" $ do
       specNegativeBecomesZero (Proxy :: Proxy Word8)
       eprop "toWord8" $ \(e :: Word8) -> e === toWord8 e
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Word8)
       eprop "toWord8 . toWord16" $ \(e :: Word8) -> e === toWord8 (toWord16 e)
       eprop "toWord8 . toWord32" $ \(e :: Word8) -> e === toWord8 (toWord32 e)
       eprop "toWord8 . toWord64" $ \(e :: Word8) -> e === toWord8 (toWord64 e)
@@ -57,6 +58,7 @@ spec =
       eprop "read . toShowS" $ \(e :: Word8) -> e === read (toShowS e "")
     describe "Word16" $ do
       specNegativeBecomesZero (Proxy :: Proxy Word16)
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Word16)
       eprop "toWord16" $ \(e :: Word16) -> e === toWord16 e
       eprop "toWord16 . toWord32" $ \(e :: Word16) -> e === toWord16 (toWord32 e)
       eprop "toWord16 . toWord64" $ \(e :: Word16) -> e === toWord16 (toWord64 e)
@@ -76,6 +78,7 @@ spec =
       eprop "read . toShowS" $ \(e :: Word16) -> e === read (toShowS e "")
     describe "Word32" $ do
       specNegativeBecomesZero (Proxy :: Proxy Word32)
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Word32)
       eprop "toWord32" $ \(e :: Word32) -> e === toWord32 e
       eprop "toWord32 . toWord64" $ \(e :: Word32) -> e === toWord32 (toWord64 e)
       prop "toWord32 . toFloat" $
@@ -97,6 +100,7 @@ spec =
       eprop "read . toShowS" $ \(e :: Word32) -> e === read (toShowS e "")
     describe "Word64" $ do
       specNegativeBecomesZero (Proxy :: Proxy Word64)
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Word64)
       eprop "toWord64" $ \(e :: Word64) -> e === toWord64 e
       prop "toWord64 . toFloat" $
         forAll (choose (0, maxFloatI)) $ \(e :: Word64) -> e === toWord64 (toFloat e)
@@ -123,6 +127,7 @@ spec =
       eprop "read . toShowS" $ \(e :: Word64) -> e === read (toShowS e "")
     describe "Word" $ do
       specNegativeBecomesZero (Proxy :: Proxy Word)
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Word)
       eprop "toWord64" $ \(e :: Word) -> fromIntegral e === toWord64 e
       prop "toWord64 . toFloat" $
         forAll (choose (0, maxFloatI)) $ \(e :: Word) -> fromIntegral e === toWord64 (toFloat e)
@@ -149,6 +154,7 @@ spec =
           shouldBeApproxIntegral 1 e (fromRealFloat (toDouble e))
       eprop "read . toShowS" $ \(e :: Word) -> e === read (toShowS e "")
     describe "Float" $ do
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Float)
       eprop "fromRealFloat . toFloat" $ \(e :: Float) -> e === fromRealFloat (toFloat e)
       eprop "fromRealFloat . toDouble" $ \(e :: Float) -> e === fromRealFloat (toDouble e)
       eprop "fromRealFloat . toRealFloat :: Float" $ \(e :: Float) ->
@@ -160,6 +166,7 @@ spec =
       --eprop "read . toShowS" $ \(e :: Float) -> e === read (toShowS e "")
       it "toWord32 (maxBound edge case)" $ toWord32 (1 :: Float) `shouldBe` maxBound
     describe "Double" $ do
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Double)
       eprop "fromRealFloat . toDouble" $ \(e :: Double) -> e === fromRealFloat (toDouble e)
       eprop "fromRealFloat . toRealFloat :: Double" $ \(e :: Double) ->
         e === fromRealFloat (toRealFloat e :: Double)
@@ -170,6 +177,7 @@ spec =
         pos = fromIntegral . max 0
     describe "Int8" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int8)
+      eprop "fromWord8 . toWord8" $ \(e :: Int8) -> e === fromWord8 (toWord8 e)
       eprop "fromRealFloat . toFloat :: Float" $ \(e :: Int8) ->
         (pos e :: Int8) === fromRealFloat (toFloat e :: Float)
       eprop "fromRealFloat . toRealFloat :: Float" $ \(e :: Int8) ->
@@ -182,6 +190,7 @@ spec =
       eprop "read . toShowS" $ \(e :: Int8) -> e === read (toShowS e "")
     describe "Int16" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int16)
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Int16)
       eprop "fromRealFloat . toFloat :: Float" $ \(e :: Int16) ->
         (pos e :: Int16) === fromRealFloat (toFloat e :: Float)
       eprop "fromRealFloat . toRealFloat :: Float" $ \(e :: Int16) ->
@@ -194,6 +203,7 @@ spec =
       eprop "read . toShowS" $ \(e :: Int16) -> e === read (toShowS e "")
     describe "Int32" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int32)
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Int32)
       prop "fromRealFloat . toFloat :: Float" $
         forAll (choose (0, maxFloatI)) $ \(e :: Int32) ->
           (pos e :: Int32) === fromRealFloat (toFloat e)
@@ -206,6 +216,7 @@ spec =
       eprop "read . toShowS" $ \(e :: Int32) -> e === read (toShowS e "")
     describe "Int64" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int64)
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Int64)
       prop "fromRealFloat . toRealFloat :: Float" $
         forAll (choose (0, maxFloatI)) $ \(e :: Int64) ->
           (pos e :: Int64) === fromRealFloat (toRealFloat e :: Float)
@@ -218,6 +229,7 @@ spec =
       eprop "read . toShowS" $ \(e :: Int64) -> e === read (toShowS e "")
     describe "Int" $ do
       specNegativeBecomesPositive (Proxy :: Proxy Int)
+      eprop "toWord8 . fromWord8" $ \(e :: Word8) -> e === toWord8 (fromWord8 e :: Int)
       prop "fromRealFloat . toRealFloat :: Float" $
         forAll (choose (0, maxFloatI)) $ \(e :: Int) ->
           (pos e :: Int) === fromRealFloat (toRealFloat e :: Float)


### PR DESCRIPTION
Having `fromWord8` allows to convert a color to, for instance, non linear SRGB colors used in SVG.

Notice that `fromWord8` for the `Int8` type is probably wrong. 